### PR TITLE
display: block; on nav-top-toggle broke the layout in IE9

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,7 @@
     <li class="nav-top-logo">
       <a href="#/" title="Tink"><span>Tink</span></a>
     </li>
-    <li class="nav-top-toggle" data-tink-sidenav-collapse="asideNavLeft" style="display:inline;">
+    <li class="nav-top-toggle" data-tink-sidenav-collapse="asideNavLeft">
       <a href="#" title="Open menu"><i class="fa fa-bars"><span class="sr-only">Open menu</span></i></a>
     </li>
     <li class="nav-top-app">

--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,7 @@
     <li class="nav-top-logo">
       <a href="#/" title="Tink"><span>Tink</span></a>
     </li>
-    <li class="nav-top-toggle" data-tink-sidenav-collapse="asideNavLeft">
+    <li class="nav-top-toggle" data-tink-sidenav-collapse="asideNavLeft" style="display:inline;">
       <a href="#" title="Open menu"><i class="fa fa-bars"><span class="sr-only">Open menu</span></i></a>
     </li>
     <li class="nav-top-app">

--- a/src/styles/tink/_navigation.scss
+++ b/src/styles/tink/_navigation.scss
@@ -128,7 +128,7 @@ html {
       .nav-top {
         &-toggle {
           @include mq($screen-sm) {
-            display: block;
+            display: inline-block;
           }
         }
       }
@@ -173,7 +173,7 @@ html {
       .nav-top {
         &-toggle {
           @include mq($screen-sm) {
-            display: block;
+            display: inline-block;
           }
         }
       }


### PR DESCRIPTION
nav-top-toggle set to display: inline-block;
updated index example to reproduce bug in IE9
